### PR TITLE
Fix in the button name

### DIFF
--- a/src/plone/app/imagecropping/browser/static/cropping.js
+++ b/src/plone/app/imagecropping/browser/static/cropping.js
@@ -2,7 +2,7 @@
 if (jQuery) {
 
     function clearCoords() {
-        $('#coords input').val('');
+        $('#coords input[hidden]').val('');
         $('#h').css({color:'red'});
         window.setTimeout(function(){
             $('#h').css({color:'inherit'});


### PR DESCRIPTION
When the clear coordinates event is called the jquery selector was taking the value of the buttons by mistake.
