### PR TITLE
Implemented came_from Parameter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,9 @@ Changelog
 - Small documentation update
   [saily]
 
+- Implementation came_from Parameter to go back to specific page
+  [Kosi81]
+
 
 0.1rc1 (2013-03-11)
 -------------------

--- a/src/plone/app/imagecropping/browser/editor.pt
+++ b/src/plone/app/imagecropping/browser/editor.pt
@@ -7,6 +7,12 @@
   <body>
 
     <metal:main fill-slot="main">
+
+      <dl class="portalMessage info" tal:condition="view/go_back_url">
+        <dt>Info:</dt>
+        <dd><a tal:content="view/go_back_title" tal:attributes="href view/go_back_url"></a></dd>
+      </dl>
+
       <h1 class="documentFirstHeading"
           i18n:translate="">
           Image Cropping Editor
@@ -75,6 +81,7 @@
                 <img class="cropbox" tal:attributes="src current_scale/image_url;" />
 
                 <div>
+                  <input type="hidden" id="came_from" name="came_from" tal:attributes="value request/came_from|nothing"/>
                   <input type="hidden" size="4" id="x1" name="x1" />
                   <input type="hidden" size="4" id="y1" name="y1" />
                   <input type="hidden" size="4" id="x2" name="x2" />

--- a/src/plone/app/imagecropping/browser/editor.py
+++ b/src/plone/app/imagecropping/browser/editor.py
@@ -9,6 +9,7 @@ from plone.app.imagecropping.interfaces import IImageCroppingUtils
 from plone.app.imaging.utils import getAllowedSizes
 from plone.registry.interfaces import IRegistry
 from zope import component
+from plone.app.uuid.utils import uuidToObject
 from zope.component._api import getUtility
 import json
 
@@ -140,6 +141,10 @@ class CroppingEditor(BrowserView):
         cropping_util = self.context.restrictedTraverse('@@crop-image')
 
         if form.get('form.button.Cancel', None) is not None:
+            if self.request.form.get("came_from", None):
+                came_from = self.request.form.get("came_from")
+                return self.request.response.redirect(
+                    uuidToObject(came_from).absolute_url())
             return self.request.response.redirect(
                 self.context.absolute_url() + '/view')
         if form.get('form.button.Delete', None) is not None:
@@ -164,6 +169,24 @@ class CroppingEditor(BrowserView):
         self.request.set('disable_plone.rightcolumn', 1)
 
         return self.template()
+
+    def go_back_url(self):
+        if self.request.form.get('form.button.Save', None) is not None \
+                or self.request.form.get('form.button.Delete', None) \
+                is not None:
+            if self.request.form.get("came_from", None):
+                came_from = self.request.form.get("came_from")
+                if uuidToObject(came_from):
+                    return uuidToObject(came_from).absolute_url()
+
+    def go_back_title(self):
+        if self.request.form.get('form.button.Save', None) is not None \
+                or self.request.form.get('form.button.Delete', None) is \
+                not None:
+            if self.request.form.get("came_from", None):
+                came_from = self.request.form.get("came_from")
+                if uuidToObject(came_from):
+                    return _(u"Go back to ") + uuidToObject(came_from).title
 
     def _min_size(self, image_size, scale_size):
         """ we need lower min-sizes if the image is smaller than the scale """


### PR DESCRIPTION
Use Case:

We implemented a direct Link from Overview Views (@the specific cropped Image) to the croppingeditor. Editor should have possibility to go to Imagecropping directly and come back to specific overview page. Therefore we give UUID of Page to croppingeditor and give Link to come back. 
