### PR TITLE
correctly check for plone.namedfile

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 0.1rc3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Check for plone.namedfile not Dexterity. It can be used seperately
+  [tom_gross]
 
 
 0.1rc2 (2013-05-03)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -8,6 +8,7 @@
 - Daniel Widerin (saily)
 - Wolfgang Thomas (pysailor)
 - Héctor Velarde (hvelarde)
+- Tom Gross (tom_gross)
 
 Credits
 -------

--- a/src/plone/app/imagecropping/__init__.py
+++ b/src/plone/app/imagecropping/__init__.py
@@ -2,11 +2,14 @@ from zope.i18nmessageid.message import MessageFactory
 import pkg_resources
 
 try:
-    pkg_resources.get_distribution('plone.dexterity')
+    pkg_resources.get_distribution('plone.namedfile')
 except pkg_resources.DistributionNotFound:
-    HAS_DEXTERITY = False
+    HAS_NAMEDFILE = False
 else:
-    HAS_DEXTERITY = True
+    HAS_NAMEDFILE = True
+
+# TODO: backwards compatibility (probably not needed)
+HAS_DEXTERITY = HAS_NAMEDFILE
 
 imagecroppingMessageFactory = MessageFactory("plone.app.imagecropping")
 PRODUCT_NAME = PAI_STORAGE_KEY = "plone.app.imagecropping"

--- a/src/plone/app/imagecropping/utils.py
+++ b/src/plone/app/imagecropping/utils.py
@@ -16,8 +16,8 @@ from zope.interface.declarations import providedBy
 
 import time
 
-from plone.app.imagecropping import HAS_DEXTERITY
-if HAS_DEXTERITY:
+from plone.app.imagecropping import HAS_NAMEDFILE
+if HAS_NAMEDFILE:
     from plone.namedfile.interfaces import IImage
     from plone.namedfile.interfaces import IImageScaleTraversable
 
@@ -108,7 +108,7 @@ class CroppingUtilsArchetype(BaseUtil):
         storage.scale(
             factory=crop_factory, fieldname=field.__name__, width=w, height=h)
 
-if HAS_DEXTERITY:
+if HAS_NAMEDFILE:
     class CroppingUtilsDexterity(BaseUtil):
         """TODO"""
 


### PR DESCRIPTION
Check for plone.namedfile not for Dexterity. It is possible to use plone.namedfile without Dexterity.
