### PR TITLE
automatic cropping behavior with direction='down'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,7 @@ Changelog
 1.3 (unreleased)
 ----------------
 
-- Introducting new scale direction "autodown". If no cropped scale is available
-  deliver direction="down" scale.
+- fix direction='down' handling. Deliver cropped scale if we have one.
   [petschki]
 
 - Purge proxy caches if needed on crop.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Introducting new scale direction "autodown". If no cropped scale is available
+  deliver direction="down" scale.
+  [petschki]
+
 - Purge proxy caches if needed on crop.
   [alecm]
 

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,13 @@ In TinyMCE it will be possible to access the cropping editor directly
 out of the image plugin right below the scale selection
 
 
+Automatic cropping behavior
+---------------------------
+
+You can use ``direction='down'`` for autocropped scales as usual.
+This package overrides the direction and delivers the cropped scale if it is available.
+
+
 Load editor as overlay
 ----------------------
 

--- a/src/plone/app/imagecropping/browser/scaling.py
+++ b/src/plone/app/imagecropping/browser/scaling.py
@@ -9,7 +9,7 @@ class ScalingOverrides(object):
 
     def _need_rescale(self, fieldname, scale):
         """If we've got a cropping annotation for the given fieldname
-           and scale, set self._rescale to False, to prevent
+           and scale, set self._allow_rescale to False, to prevent
            plone.app.imaging traverser to overwrite our cropped scale
 
            since the self.modified() method does not know about the

--- a/src/plone/app/imagecropping/browser/scaling.py
+++ b/src/plone/app/imagecropping/browser/scaling.py
@@ -13,7 +13,7 @@ class ScalingOverrides(object):
            plone.app.imaging traverser to overwrite our cropped scale
 
            since the self.modified() method does not know about the
-           currently requested scale name, we need to use the _rescale
+           currently requested scale name, we need to use the _allow_rescale
            property
         """
         cropped = IAnnotations(self.context).get(PAI_STORAGE_KEY)

--- a/src/plone/app/imagecropping/browser/scalingat.py
+++ b/src/plone/app/imagecropping/browser/scalingat.py
@@ -20,7 +20,7 @@ class ImageScalingAT(ScalingOverrides, BaseImageScaling):
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               **parameters):
         self._need_rescale(fieldname, scale)
-        # XXX: if direction is 'down' and we have a cropped scale
+        # if direction is 'down' and we have a cropped scale
         # deliver it instead of standard 'down' scale
         p_dir = parameters.get('direction', '')
         if p_dir == 'down' and not self._allow_rescale:

--- a/src/plone/app/imagecropping/browser/scalingat.py
+++ b/src/plone/app/imagecropping/browser/scalingat.py
@@ -20,5 +20,10 @@ class ImageScalingAT(ScalingOverrides, BaseImageScaling):
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               **parameters):
         self._need_rescale(fieldname, scale)
+        # XXX: if direction is 'down' and we have a cropped scale
+        # deliver it instead of standard 'down' scale
+        p_dir = parameters.get('direction', '')
+        if p_dir == 'down' and not self._allow_rescale:
+            del parameters['direction']
         return super(ImageScalingAT, self).scale(
             fieldname, scale, height, width, **parameters)

--- a/src/plone/app/imagecropping/browser/scalingdx.py
+++ b/src/plone/app/imagecropping/browser/scalingdx.py
@@ -25,7 +25,7 @@ class ImageScalingDX(ScalingOverrides, NFImageScaling):
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               direction='thumbnail', **parameters):
         self._need_rescale(fieldname, scale)
-        # XXX: if direction is 'down' and we have a cropped scale
+        # if direction is 'down' and we have a cropped scale
         # deliver it instead of standard 'down' scale
         if direction == 'down' and not self._allow_rescale:
             direction = 'thumbnail'

--- a/src/plone/app/imagecropping/browser/scalingdx.py
+++ b/src/plone/app/imagecropping/browser/scalingdx.py
@@ -25,10 +25,9 @@ class ImageScalingDX(ScalingOverrides, NFImageScaling):
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               direction='thumbnail', **parameters):
         self._need_rescale(fieldname, scale)
-        # XXX: introduce a new direction 'autodown'
-        # this returns the cropped scale if available, otherwise the
-        # normal 'down'-scaled scale
-        if direction == 'autodown':
-            direction = self._allow_rescale and 'down' or 'thumbnail'
+        # XXX: if direction is 'down' and we have a cropped scale
+        # deliver it instead of standard 'down' scale
+        if direction == 'down' and not self._allow_rescale:
+            direction = 'thumbnail'
         return super(ImageScalingDX, self).scale(
             fieldname, scale, height, width, direction, **parameters)

--- a/src/plone/app/imagecropping/browser/scalingdx.py
+++ b/src/plone/app/imagecropping/browser/scalingdx.py
@@ -25,5 +25,10 @@ class ImageScalingDX(ScalingOverrides, NFImageScaling):
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               direction='thumbnail', **parameters):
         self._need_rescale(fieldname, scale)
+        # XXX: introduce a new direction 'autodown'
+        # this returns the cropped scale if available, otherwise the
+        # normal 'down'-scaled scale
+        if direction == 'autodown':
+            direction = self._allow_rescale and 'down' or 'thumbnail'
         return super(ImageScalingDX, self).scale(
             fieldname, scale, height, width, direction, **parameters)

--- a/src/plone/app/imagecropping/tests/test_cropping.py
+++ b/src/plone/app/imagecropping/tests/test_cropping.py
@@ -258,3 +258,21 @@ class TestCroppingAT(unittest.TestCase):
             'new thumb is different from old thumb scale after '
             'copying image (attribute access)'
         )
+
+    def test_autocrop(self):
+        """ check direction='down' for cropped and un-cropped image scales
+        """
+        traverse = self.portal.REQUEST.traverseName
+
+        # auto-cropped scale
+        img_scales = traverse(self.img, '@@images')
+        auto_crop = img_scales.scale('image', 'thumb', direction='down')
+
+        # cropped scale
+        view = self.img.restrictedTraverse('@@crop-image')
+        view._crop(fieldname='image', scale='thumb', box=(0, 0, 200, 200))
+        manual_crop = img_scales.scale('image', 'thumb', direction='down')
+        self.assertEqual(
+            (auto_crop.width, auto_crop.height),
+            (manual_crop.width, manual_crop.height))
+        self.assertNotEqual(auto_crop.data, manual_crop.data)

--- a/src/plone/app/imagecropping/tests/test_cropping_dx.py
+++ b/src/plone/app/imagecropping/tests/test_cropping_dx.py
@@ -293,3 +293,21 @@ class TestCroppingDX(unittest.TestCase):
         #     'new thumb is different from old thumb scale after '
         #     'copying image (attribute access)'
         # )
+
+    def test_autocrop(self):
+        """ check direction='down' for cropped and un-cropped image scales
+        """
+        traverse = self.portal.REQUEST.traverseName
+
+        # auto-cropped scale
+        img_scales = traverse(self.img, '@@images')
+        auto_crop = img_scales.scale('image', 'thumb', direction='down')
+
+        # cropped scale
+        view = self.img.restrictedTraverse('@@crop-image')
+        view._crop(fieldname='image', scale='thumb', box=(0, 0, 200, 200))
+        manual_crop = img_scales.scale('image', 'thumb', direction='down')
+        self.assertEqual(
+            (auto_crop.width, auto_crop.height),
+            (manual_crop.width, manual_crop.height))
+        self.assertNotEqual(auto_crop.data, manual_crop.data)


### PR DESCRIPTION
deliver individual cropped scale instead of default 'down' cropped.