### PR TITLE
Generate cropped scales instead of uncropped scales after storage._cleanup() has run.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.4 (unreleased)
 ----------------
 
+- Ensure cropped scales are re-generated, rather than uncropped ones, when stored scales go missing.
+  [alecm]
+
 - Housekeeping: upgrades at one place, zca decorators, travis caching
   [jensens]
 

--- a/src/plone/app/imagecropping/browser/scaling.py
+++ b/src/plone/app/imagecropping/browser/scaling.py
@@ -1,11 +1,29 @@
 # -*- coding: utf-8 -*-
+from cStringIO import StringIO
+from logging import exception
+from logging import getLogger
+
 from plone.app.imagecropping import PAI_STORAGE_KEY
+from plone.app.imagecropping.interfaces import IImageCroppingUtils
+from plone.app.imaging.interfaces import IImagingSchema
+from zope.component.hooks import getSite
 from zope.annotation.interfaces import IAnnotations
+from ZODB.POSException import ConflictError
+
+try:
+    import PIL.Image
+    from plone.scale.scale import scaleImage
+except ImportError:
+    logger = getLogger('plone.app.imaging')
+    logger.warn("Warning: no Python Imaging Libraries (PIL) found. "
+                "Can't scale images.")
 
 
 class ScalingOverrides(object):
 
     _allow_rescale = True
+    DEFAULT_FORMAT = 'PNG'
+    _scale_name = None
 
     def _need_rescale(self, fieldname, scale):
         """If we've got a cropping annotation for the given fieldname
@@ -16,8 +34,50 @@ class ScalingOverrides(object):
            currently requested scale name, we need to use the _allow_rescale
            property
         """
-        cropped = IAnnotations(self.context).get(PAI_STORAGE_KEY)
-        if cropped and '{0:s}_{1:s}'.format(fieldname, scale) in cropped:
+        if self._get_crop_box(fieldname, scale):
             self._allow_rescale = False
         else:
             self._allow_rescale = True
+
+    def _get_crop_box(self, fieldname, scale):
+        cropped = IAnnotations(self.context).get(PAI_STORAGE_KEY)
+        if cropped:
+            return cropped.get('{0:s}_{1:s}'.format(fieldname, scale))
+
+    def _cropped_image(self, fieldname, box, direction='keep', **parameters):
+        croputils = IImageCroppingUtils(self.context)
+        data = croputils.get_image_data(fieldname)
+
+        original_file = StringIO(data)
+        image = PIL.Image.open(original_file)
+        image_format = image.format or self.DEFAULT_FORMAT
+
+        cropped_image = image.crop(box)
+        cropped_image_file = StringIO()
+        cropped_image.save(cropped_image_file, image_format, quality=100)
+        cropped_image_file.seek(0)
+
+        if 'quality' not in parameters:
+            imaging_schema = IImagingSchema(getSite())
+            parameters['quality'] = getattr(imaging_schema, 'quality', None)
+
+        return scaleImage(cropped_image_file, direction=direction,
+                          **parameters)
+
+    def create(self, fieldname, direction='keep', **parameters):
+        """ override factory for image scale creation to perform cropping,
+            when a crop is set """
+        if self._scale_name:
+            scale = self._scale_name
+            box = self._get_crop_box(fieldname, scale)
+            if box is not None:
+                try:
+                    return self._cropped_image(fieldname, box, direction,
+                                               **parameters)
+                except (ConflictError, KeyboardInterrupt):
+                    raise
+                except Exception:
+                    exception('could not scale "%r" of %r',
+                              fieldname, self.context.absolute_url())
+        return super(ScalingOverrides, self).create(fieldname, direction,
+                                                    **parameters)

--- a/src/plone/app/imagecropping/browser/scaling.py
+++ b/src/plone/app/imagecropping/browser/scaling.py
@@ -44,6 +44,9 @@ class ScalingOverrides(object):
         if cropped:
             return cropped.get('{0:s}_{1:s}'.format(fieldname, scale))
 
+    def _wrap_image(self, data, fmt='PNG', fieldname=None):
+        return data
+
     def _cropped_image(self, fieldname, box, direction='keep', **parameters):
         croputils = IImageCroppingUtils(self.context)
         data = croputils.get_image_data(fieldname)
@@ -61,8 +64,10 @@ class ScalingOverrides(object):
             imaging_schema = IImagingSchema(getSite())
             parameters['quality'] = getattr(imaging_schema, 'quality', None)
 
-        return scaleImage(cropped_image_file, direction=direction,
-                          **parameters)
+        data, fmt, size = scaleImage(cropped_image_file, direction=direction,
+                                     **parameters)
+
+        return self._wrap_image(data, fmt, fieldname), fmt, size
 
     def create(self, fieldname, direction='keep', **parameters):
         """ override factory for image scale creation to perform cropping,

--- a/src/plone/app/imagecropping/browser/scalingat.py
+++ b/src/plone/app/imagecropping/browser/scalingat.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .scaling import ScalingOverrides
 from plone.app.imaging.scaling import ImageScaling as BaseImageScaling
+from ZODB.blob import Blob
 
 
 class ImageScalingAT(ScalingOverrides, BaseImageScaling):
@@ -16,6 +17,13 @@ class ImageScalingAT(ScalingOverrides, BaseImageScaling):
             return super(ImageScalingAT, self).modified()
         else:
             return 1
+
+    def _wrap_image(self, data, fmt='PNG', fieldname=None):
+        blob = Blob()
+        result = blob.open('w')
+        result.write(data)
+        result.close()
+        return blob
 
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               **parameters):

--- a/src/plone/app/imagecropping/browser/scalingat.py
+++ b/src/plone/app/imagecropping/browser/scalingat.py
@@ -19,6 +19,7 @@ class ImageScalingAT(ScalingOverrides, BaseImageScaling):
 
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               **parameters):
+        self._scale_name = scale
         self._need_rescale(fieldname, scale)
         # if direction is 'down' and we have a cropped scale
         # deliver it instead of standard 'down' scale

--- a/src/plone/app/imagecropping/browser/scalingdx.py
+++ b/src/plone/app/imagecropping/browser/scalingdx.py
@@ -24,6 +24,7 @@ class ImageScalingDX(ScalingOverrides, NFImageScaling):
 
     def scale(self, fieldname=None, scale=None, height=None, width=None,
               direction='thumbnail', **parameters):
+        self._scale_name = scale
         self._need_rescale(fieldname, scale)
         # if direction is 'down' and we have a cropped scale
         # deliver it instead of standard 'down' scale
@@ -31,3 +32,17 @@ class ImageScalingDX(ScalingOverrides, NFImageScaling):
             direction = 'thumbnail'
         return super(ImageScalingDX, self).scale(
             fieldname, scale, height, width, direction, **parameters)
+
+    def _cropped_image(self, fieldname, box, direction='keep', **parameters):
+        orig_value = getattr(self.context, fieldname)
+        if orig_value is None:
+            return
+
+        data, fmt, dimensions = super(ImageScalingDX, self)._cropped_image(
+            fieldname, box, direction, **parameters)
+
+        mimetype = 'image/%s' % fmt.lower()
+        value = orig_value.__class__(
+            data, contentType=mimetype, filename=orig_value.filename)
+        value.fieldname = fieldname
+        return value

--- a/src/plone/app/imagecropping/browser/scalingdx.py
+++ b/src/plone/app/imagecropping/browser/scalingdx.py
@@ -33,14 +33,12 @@ class ImageScalingDX(ScalingOverrides, NFImageScaling):
         return super(ImageScalingDX, self).scale(
             fieldname, scale, height, width, direction, **parameters)
 
-    def _cropped_image(self, fieldname, box, direction='keep', **parameters):
+    def _wrap_image(self, data, fmt='PNG', fieldname=None):
+        if not fieldname:
+            return
         orig_value = getattr(self.context, fieldname)
         if orig_value is None:
             return
-
-        data, fmt, dimensions = super(ImageScalingDX, self)._cropped_image(
-            fieldname, box, direction, **parameters)
-
         mimetype = 'image/%s' % fmt.lower()
         value = orig_value.__class__(
             data, contentType=mimetype, filename=orig_value.filename)

--- a/src/plone/app/imagecropping/tests/test_cropping.py
+++ b/src/plone/app/imagecropping/tests/test_cropping.py
@@ -292,11 +292,18 @@ class TestCroppingAT(unittest.TestCase):
         self.assertNotEqual(thumb.data, uncropped_thumb.data)
 
         storage = AnnotationStorage(self.img)
-        self.assertEqual(len(storage), 1)
+        orig_len = len(storage)
+        self.assertGreaterEqual(orig_len, 1)
 
-        # Maunally clear image crops from storage
-        storage.clear()
-        self.assertEqual(len(storage), 0)
+        # Maunally clear image crops from storage (clear doesn't work on Plone 4.2?)
+        for k in storage.keys():
+            try:
+                del storage[k]
+            except KeyError:
+                pass
+
+        # We have removed some, but not (on Plone 4.2) all items
+        self.assertLess(len(storage), orig_len)
 
         # Newly created scale should be cropped
         scales = traverse(self.img, '@@images')

--- a/src/plone/app/imagecropping/tests/test_cropping_dx.py
+++ b/src/plone/app/imagecropping/tests/test_cropping_dx.py
@@ -8,6 +8,7 @@ from plone.app.imagecropping import tests
 from plone.app.imagecropping.testing import \
     PLONE_APP_IMAGECROPPING_INTEGRATION_DX
 from plone.namedfile.file import NamedBlobImage
+from plone.scale.storage import AnnotationStorage
 from unittest2.case import skip
 from zope import event
 from zope.annotation.interfaces import IAnnotations
@@ -311,3 +312,32 @@ class TestCroppingDX(unittest.TestCase):
             (auto_crop.width, auto_crop.height),
             (manual_crop.width, manual_crop.height))
         self.assertNotEqual(auto_crop.data, manual_crop.data)
+
+    def test_crops_recreated(self):
+        view = self.img.restrictedTraverse('@@crop-image')
+        traverse = self.portal.REQUEST.traverseName
+        scales = traverse(self.img, '@@images')
+        uncropped_thumb = scales.scale('image', 'thumb')
+
+        # store cropped version for thumb and check if the result
+        # is a square now
+        view._crop(fieldname='image', scale='thumb', box=(14, 14, 218, 218))
+
+        thumb = scales.scale('image', 'thumb')
+        self.assertNotEqual(
+            (uncropped_thumb.width, uncropped_thumb.height),
+            (thumb.width, thumb.height))
+
+        storage = AnnotationStorage(self.img)
+        self.assertEqual(len(storage), 1)
+
+        # Maunally clear image crops from storage
+        storage.clear()
+        self.assertEqual(len(storage), 0)
+
+        # Newly created scale should be cropped
+        scales = traverse(self.img, '@@images')
+        new_thumb = scales.scale('image', 'thumb')
+        self.assertEqual(
+            (new_thumb.width, new_thumb.height),
+            (thumb.width, thumb.height))

--- a/src/plone/app/imagecropping/tests/test_cropping_dx.py
+++ b/src/plone/app/imagecropping/tests/test_cropping_dx.py
@@ -329,11 +329,18 @@ class TestCroppingDX(unittest.TestCase):
             (thumb.width, thumb.height))
 
         storage = AnnotationStorage(self.img)
-        self.assertEqual(len(storage), 1)
+        orig_len = len(storage)
+        self.assertGreaterEqual(orig_len, 1)
 
-        # Maunally clear image crops from storage
-        storage.clear()
-        self.assertEqual(len(storage), 0)
+        # Maunally clear image crops from storage (clear doesn't work on Plone 4.2?)
+        for k in storage.keys():
+            try:
+                del storage[k]
+            except KeyError:
+                pass
+
+        # We have removed some, but not (on Plone 4.2) all items
+        self.assertLess(len(storage), orig_len)
 
         # Newly created scale should be cropped
         scales = traverse(self.img, '@@images')


### PR DESCRIPTION
This PR is for p.a.imagecropping 1.x and Plone 4.x only, it fixes the issues with disappearing crops for those versions. It appears this issue is already fixed in a different way on master using new features from plone.scale and plone.namedfile, but that branch is incompatible with Plone 4.x AFAICT.