### PR TITLE
Include labels file only where needed

### DIFF
--- a/src/plone/app/imagecropping/browser/static/cropscaleselect.less
+++ b/src/plone/app/imagecropping/browser/static/cropscaleselect.less
@@ -1,9 +1,9 @@
 @import "@{bowerPath}/bootstrap/less/variables.less";
 @import "@{bowerPath}/bootstrap/less/mixins.less";
-@import "@{bowerPath}/bootstrap/less/labels.less";
 @import (inline) 'cropper-dist/cropper.min.css';
 
 .pat-imagecrop-scaleselect {
+    @import "@{bowerPath}/bootstrap/less/labels.less";
     div.items.scaleselector {
         padding-left: 0px;
         padding-right: 0px;


### PR DESCRIPTION
include labels less file inside the scale editor, not to change the color of other labels in the site. 

Fixes #78

