### PR TITLE
Fix upgrade step by clearing `plone-logged-in` bundle dependency

### DIFF
--- a/src/plone/app/imagecropping/upgrades/profiles/2300_to_2301/registry.xml
+++ b/src/plone/app/imagecropping/upgrades/profiles/2300_to_2301/registry.xml
@@ -4,6 +4,7 @@
   >
     <value key="jscompilation">++resource++plone.app.imagecropping.static/imagecropping-remote.min.js</value>
     <value key="csscompilation" />
+    <value key="depends"></value>
     <value key="load_async">False</value>
     <value key="load_defer">False</value>
   </records>


### PR DESCRIPTION
This avoids `Bundle 'plone_app_imagecropping' has a non existing dependency on 'plone-logged-in'.` error after migration.

@petschki OK for you ?