### PR TITLE
Make sure the hash key changes after cropping an image.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,7 @@ indent_size = 2
 [*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
 # 2 space indentation
 indent_size = 2
+max_line_length = 80
 
 [{Makefile,.gitmodules}]
 # Tab indentation (no size specified, but view as 4 spaces)

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -13,6 +13,16 @@ on:
       - main
   workflow_dispatch:
 
+##
+# To set environment variables for all jobs, add in .meta.toml:
+# [github]
+# env = """
+#     debug: 1
+#     image-name: 'org/image'
+#     image-tag: 'latest'
+# """
+##
+
 jobs:
   qa:
     uses: plone/meta/.github/workflows/qa.yml@main

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -26,16 +26,12 @@ on:
 jobs:
   qa:
     uses: plone/meta/.github/workflows/qa.yml@main
-  test:
-    uses: plone/meta/.github/workflows/test.yml@main
   coverage:
     uses: plone/meta/.github/workflows/coverage.yml@main
   dependencies:
     uses: plone/meta/.github/workflows/dependencies.yml@main
   release_ready:
     uses: plone/meta/.github/workflows/release_ready.yml@main
-  circular:
-    uses: plone/meta/.github/workflows/circular.yml@main
 
 ##
 # To modify the list of default jobs being created add in .meta.toml:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
           - "6.0-dev"
     steps:
       - uses: actions/checkout@v2
-      - uses: nanasess/setup-chromedriver@v1
+      - uses: nanasess/setup-chromedriver@v2
 
       - name: Setup Plone ${{ matrix.plone }} with Python ${{ matrix.python }}
-        uses: plone/setup-plone@v1.0.0
+        uses: plone/setup-plone@v2.0.0
         with:
           python-version: ${{ matrix.python }}
           plone-version: ${{ matrix.plone }}
@@ -46,11 +46,12 @@ jobs:
         run: |
           make VENV=off lint
 
-      - name: Run tests
+      - name: Start Browser
         run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          sleep 2
-          export ROBOT_BROWSER=headlesschrome &
-          make VENV=off test-ignore-warnings
+          sudo Xvfb -ac :99 -screen 0 1920x1280x24 > /dev/null 2>&1 &
+
+      - name: Run tests
+        run: |
+          ROBOT_BROWSER=headlesschrome make VENV=off test-ignore-warnings

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.pyc
 *.pyo
 
+# translation related
+*.mo
+
 # tools related
 build/
 .coverage

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "c1677eef"
+commit-id = "21759c8c"
 
 [pyproject]
 codespell_skip = "*.js,*.min.js,*.min.js.map,*.css.map,yarn.lock,robot_*,test_*"

--- a/.meta.toml
+++ b/.meta.toml
@@ -17,3 +17,11 @@ test_*
 robot_*
 forest.*
 """
+
+[github]
+jobs = [
+    "qa",
+    "coverage",
+    "dependencies",
+    "release_ready",
+    ]

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "21759c8c"
+commit-id = "ea1b238f"
 
 [pyproject]
 codespell_skip = "*.js,*.min.js,*.min.js.map,*.css.map,yarn.lock,robot_*,test_*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.10.1
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -32,7 +32,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
 
@@ -71,9 +71,19 @@ repos:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.0.0"
+    rev: "6.1.0"
     hooks:
     -   id: i18ndude
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  i18ndude_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
+
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Bug fixes:
   [petschki] (#0)
 
 
+- Make sure the hash key changes after cropping an image.
+  [mathias.leimgruber]
+
+
 Internal:
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,42 +1,6 @@
 # Generated from:
 # https://github.com/plone/meta/tree/master/config/default
 # See the inline comments on how to expand/tweak this configuration file
-[tool.towncrier]
-directory = "news/"
-filename = "CHANGES.rst"
-title_format = "{version} ({project_date})"
-underlines = ["-", ""]
-
-[[tool.towncrier.type]]
-directory = "breaking"
-name = "Breaking changes:"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "feature"
-name = "New features:"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "bugfix"
-name = "Bug fixes:"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "internal"
-name = "Internal:"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "documentation"
-name = "Documentation:"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "tests"
-name = "Tests"
-showcontent = true
-
 ##
 # Add extra configuration options in .meta.toml:
 #  [pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ Pillow = ['PIL']
 #    "gitpython = ['git']",
 #    "pygithub = ['github']",
 #  ]
-#  """
 ##
 
 [tool.check-manifest]

--- a/src/plone/app/imagecropping/storage.py
+++ b/src/plone/app/imagecropping/storage.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from persistent.dict import PersistentDict
 from plone.app.imagecropping import PAI_STORAGE_KEY
 from plone.app.imagecropping.events import CroppingInfoChangedEvent
@@ -44,6 +45,12 @@ class Storage:
         self.remove(fieldname, scale)
         key = self._key(fieldname, scale)
         self._storage[key] = box
+
+        context = aq_base(self.context)
+        field = getattr(context, fieldname, None)
+        if field is not None:
+            field._p_changed = True  # Force a new hash key
+
         notify(CroppingInfoChangedEvent(self.context))
 
     def read(self, fieldname, scale):

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,13 @@ commands =
     echo "Unrecognized environment name {envname}"
     false
 
+[testenv:init]
+description = Prepare environment
+skip_install = true
+commands =
+    echo "Initial setup complete"
+
+
 [testenv:format]
 description = automatically reformat code
 skip_install = true
@@ -86,11 +93,20 @@ set_env =
 #  test_environment_variables = """
 #      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
 #  """
+#
+# Set constrain_package_deps .meta.toml:
+#  [tox]
+#  constrain_package_deps = "false"
 ##
 deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    
 ##
+# Specify additional deps in .meta.toml:
+#  [tox]
+#  test_deps_additional = "-esources/plonegovbr.portal_base[test]"
+#
 # Specify a custom constraints file in .meta.toml:
 #  [tox]
 #  constraints_file = "https://my-server.com/constraints.txt"
@@ -128,6 +144,7 @@ deps =
     coverage
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    
 commands =
     coverage run --branch --source plone.app.imagecropping {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}/src -s plone.app.imagecropping {posargs}
     coverage report -m --format markdown
@@ -144,6 +161,7 @@ deps =
     build
     towncrier
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    
 commands =
     # fake version to not have to install the package
     # we build the change log as news entries might break
@@ -171,6 +189,7 @@ deps =
     pipdeptree
     pipforester
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'

--- a/tox.ini
+++ b/tox.ini
@@ -159,14 +159,9 @@ skip_install = true
 deps =
     twine
     build
-    towncrier
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
     
 commands =
-    # fake version to not have to install the package
-    # we build the change log as news entries might break
-    # the README that is displayed on PyPI
-    towncrier build --version=100.0.0 --yes
     python -m build --sdist --no-isolation
     twine check dist/*
 


### PR DESCRIPTION
Problem:

Even though an image gets changed via cropping it does maintain the same url. Which leads cache/proxy and browsers to potentially **not** download the new version of the cropped image. 

Example:
After uploading a new image the url to the thumb scale is http://nohost/plone/testimage/@@images/image-128-fba13e5e2040bf30b80360aeaf2bb42f.png

After cropping the url is still http://nohost/plone/testimage/@@images/image-128-fba13e5e2040bf30b80360aeaf2bb42f.png


Explenation:
One part of the hash key in the default storage (IImageScaleStorage) is the _p_mtime (modification time if an object got changed during a transaction). This is basically the only parameter that we can change, without rewriting the storage, image factory and utilities. 

Solution:
Mark the ImageBlobField as changed if a scale gets cropped.
This way we force the storage to generate a new has key for (all) the scales. 

