### PR TITLE
Fix issue with scale height `65536` used as "flexible height"

### DIFF
--- a/news/144.bugfix
+++ b/news/144.bugfix
@@ -1,0 +1,3 @@
+Fix recreation of `image_scale` catalog metadata and update hashkey after
+changing cropping information.
+[petschki, mrTango]

--- a/src/plone/app/imagecropping/browser/editor.pt
+++ b/src/plone/app/imagecropping/browser/editor.pt
@@ -87,7 +87,7 @@
                           <div class="d-flex justify-content-between align-items-center">
                             <span>
                               <strong>${scale/title}</strong>
-                              <span i18n:translate="">${scale/target_width}&times;${scale/target_height}:</span>
+                              <span>${scale/target_width}&times;${python:"max" if scale.get('target_height_orig') else scale['target_height']}:</span>
                             </span>
                             <span class="nowrap">
                               <span class="badge bg-success cropped"

--- a/src/plone/app/imagecropping/browser/editor.pt
+++ b/src/plone/app/imagecropping/browser/editor.pt
@@ -87,7 +87,7 @@
                           <div class="d-flex justify-content-between align-items-center">
                             <span>
                               <strong>${scale/title}</strong>
-                              <span>${scale/target_width}&times;${python:"max" if scale.get('target_height_orig') else scale['target_height']}:</span>
+                              <span i18n:translate="">${scale/target_width}&times;${python:"max" if scale.get('target_height_orig') else scale['target_height']}:</span>
                             </span>
                             <span class="nowrap">
                               <span class="badge bg-success cropped"

--- a/src/plone/app/imagecropping/browser/editor.py
+++ b/src/plone/app/imagecropping/browser/editor.py
@@ -142,8 +142,7 @@ class CroppingEditor(BrowserView):
             scale["aspect_ratio"] = "{:.2f}".format(
                 float(target_size[0]) / float(target_size[1])
             )
-
-        scale["can_scale"] = target_size[0] <= true_size[0]
+        scale["can_scale"] = target_size[0] <= true_size[0] and target_size[1] <= true_size[1]
         return scale
 
     def _scales(self, fieldname):

--- a/src/plone/app/imagecropping/browser/editor.py
+++ b/src/plone/app/imagecropping/browser/editor.py
@@ -102,7 +102,7 @@ class CroppingEditor(BrowserView):
         # lookup saved crop info
         storage = Storage(self.context)
         current_box = storage.read(fieldname, scale_id)
-        initial_box = self._initial_size(true_size, target_size)
+        initial_box = self._initial_size(true_size, target_size[:2])
 
         if current_box is None:
             current_box = initial_box
@@ -117,6 +117,10 @@ class CroppingEditor(BrowserView):
         # images target dimensions
         scale["target_width"] = target_size[0]
         scale["target_height"] = target_size[1]
+
+        if len(target_size) == 3:
+            # original height was scaled down
+            scale["target_height_orig"] = target_size[2]
 
         # initial selected crop
         scale["initial"] = {
@@ -138,8 +142,9 @@ class CroppingEditor(BrowserView):
             scale["aspect_ratio"] = "{:.2f}".format(
                 float(target_size[0]) / float(target_size[1])
             )
+
         scale["can_scale"] = (
-            target_size[0] <= true_size[0] and target_size[1] <= true_size[1]
+            target_size[0] <= true_size[0]
         )
         return scale
 
@@ -158,6 +163,15 @@ class CroppingEditor(BrowserView):
         on the current content with the given fieldname and interface."""
         true_size = self._croputils.get_image_size(fieldname)
         for scale_id, target_size in self._scales(fieldname):
+            # scale down target height if too large
+            # in this case we calculate the height by the original ratio
+            if target_size[1] >= 65536:
+                target_size = (
+                    target_size[0],
+                    int(round(target_size[0] / true_size[0] * true_size[1])),
+                    # save original height and show info in editor
+                    target_size[1],
+                )
             yield self._scale_info(fieldname, scale_id, target_size, true_size)
 
     @property

--- a/src/plone/app/imagecropping/browser/editor.py
+++ b/src/plone/app/imagecropping/browser/editor.py
@@ -143,9 +143,7 @@ class CroppingEditor(BrowserView):
                 float(target_size[0]) / float(target_size[1])
             )
 
-        scale["can_scale"] = (
-            target_size[0] <= true_size[0]
-        )
+        scale["can_scale"] = target_size[0] <= true_size[0]
         return scale
 
     def _scales(self, fieldname):

--- a/src/plone/app/imagecropping/browser/editor.py
+++ b/src/plone/app/imagecropping/browser/editor.py
@@ -142,7 +142,9 @@ class CroppingEditor(BrowserView):
             scale["aspect_ratio"] = "{:.2f}".format(
                 float(target_size[0]) / float(target_size[1])
             )
-        scale["can_scale"] = target_size[0] <= true_size[0] and target_size[1] <= true_size[1]
+        scale["can_scale"] = (
+            target_size[0] <= true_size[0] and target_size[1] <= true_size[1]
+        )
         return scale
 
     def _scales(self, fieldname):

--- a/src/plone/app/imagecropping/configure.zcml
+++ b/src/plone/app/imagecropping/configure.zcml
@@ -9,7 +9,10 @@
 
   <i18n:registerTranslations directory="locales" />
 
-  <include package="Products.CMFCore" file="permissions.zcml" />
+  <include
+      package="Products.CMFCore"
+      file="permissions.zcml"
+      />
 
   <include package=".browser" />
   <include package=".upgrades" />

--- a/src/plone/app/imagecropping/configure.zcml
+++ b/src/plone/app/imagecropping/configure.zcml
@@ -39,6 +39,7 @@
       />
 
   <subscriber handler=".subscribers.apply_crops_after_copy" />
+  <subscriber handler=".subscribers.reindex_after_crop_change" />
 
   <class class="plone.app.contenttypes.content.Image">
     <implements interface=".dx.IImageCroppingDX" />

--- a/src/plone/app/imagecropping/storage.py
+++ b/src/plone/app/imagecropping/storage.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_base
+from DateTime import DateTime
 from persistent.dict import PersistentDict
 from plone.app.imagecropping import PAI_STORAGE_KEY
 from plone.app.imagecropping.events import CroppingInfoChangedEvent
@@ -49,7 +50,7 @@ class Storage:
         context = aq_base(self.context)
         field = getattr(context, fieldname, None)
         if field is not None:
-            field._p_changed = True  # Force a new hash key
+            field._modified = DateTime().millis()  # Force a new hash key
 
         notify(CroppingInfoChangedEvent(self.context))
 

--- a/src/plone/app/imagecropping/subscribers.py
+++ b/src/plone/app/imagecropping/subscribers.py
@@ -1,4 +1,5 @@
 from plone.app.imagecropping import PAI_STORAGE_KEY
+from plone.app.imagecropping.interfaces import ICroppingInfoChangedEvent
 from plone.app.imagecropping.interfaces import IImageCroppingMarker
 from plone.app.imagecropping.interfaces import IImageCroppingUtils
 from zope.annotation.interfaces import IAnnotations
@@ -21,3 +22,9 @@ def apply_crops_after_copy(context, event):
             if crop_key.startswith(fieldname):
                 scalename = crop_key[len(fieldname) + 1 :]
                 cropper._crop(fieldname, scalename, crops[crop_key])
+
+
+@adapter(IImageCroppingMarker, ICroppingInfoChangedEvent)
+def reindex_after_crop_change(context, event):
+    # reindex to recreate `image_scales` metadata in catalog
+    context.reindexObject()

--- a/src/plone/app/imagecropping/tests/test_cropping.py
+++ b/src/plone/app/imagecropping/tests/test_cropping.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_parent
+from plone import api
 from plone.app.imagecropping import PAI_STORAGE_KEY
 from plone.app.imagecropping.testing import IMAGECROPPING_FUNCTIONAL
 from plone.app.imagecropping.tests import dummy_named_blob_jpg_image
@@ -110,6 +111,19 @@ class TestCroppingDX(unittest.TestCase):
         tag_thumb3 = thumb3.tag(scale="thumb")
 
         self.assertNotEqual(tag_thumb2, tag_thumb3)
+
+    def test_cropping_udates_image_scales_in_catalog(self):
+        view = self.img.restrictedTraverse("@@crop-image")
+        view._crop(fieldname="image", scale="thumb", box=(14, 14, 218, 218))
+        transaction.commit()  # needed in order to have a _p_mtime on objects
+        img_brain = api.content.find(UID=self.img.UID())[0]
+        view._crop(fieldname="image", scale="thumb", box=(14, 14, 100, 100))
+        transaction.commit()
+        img_brain_new = api.content.find(UID=self.img.UID())[0]
+        self.assertNotEqual(
+            img_brain.image_scales['image'][0]['scales']['thumb']['download'],
+            img_brain_new.image_scales['image'][0]['scales']['thumb']['download'],
+        )
 
     def test_image_formats(self):
         """make sure the scales have the same format as the original image"""

--- a/src/plone/app/imagecropping/tests/test_cropping.py
+++ b/src/plone/app/imagecropping/tests/test_cropping.py
@@ -85,17 +85,16 @@ class TestCroppingDX(unittest.TestCase):
             "imagescaling does not return cropped image",
         )
 
-    def test_create_new_key_hash_for_copped_images(self):
-        """Even though the origunal image did not change,
+    def test_create_new_hashkey_for_cropped_images(self):
+        """Even though the original image did not change,
         the cache key needs to change, otherwise cache proxies and browser
-        don't about the 'new' cropped image.
+        don't know about the 'new' cropped image.
 
         Since the original image does not change, we need to force update
         the modification (_p_mtime) on the field
 
-        Hint: the has key has the modification time included.
+        Hint: the hash key has the modification time included.
         """
-
         view = self.img.restrictedTraverse("@@crop-image")
         view._crop(fieldname="image", scale="thumb", box=(14, 14, 218, 218))
         transaction.commit()  # needed in order to have a _p_mtime on objects

--- a/src/plone/app/imagecropping/tests/test_cropping.py
+++ b/src/plone/app/imagecropping/tests/test_cropping.py
@@ -121,8 +121,8 @@ class TestCroppingDX(unittest.TestCase):
         transaction.commit()
         img_brain_new = api.content.find(UID=self.img.UID())[0]
         self.assertNotEqual(
-            img_brain.image_scales['image'][0]['scales']['thumb']['download'],
-            img_brain_new.image_scales['image'][0]['scales']['thumb']['download'],
+            img_brain.image_scales["image"][0]["scales"]["thumb"]["download"],
+            img_brain_new.image_scales["image"][0]["scales"]["thumb"]["download"],
         )
 
     def test_image_formats(self):

--- a/src/plone/app/imagecropping/tests/test_editor.py
+++ b/src/plone/app/imagecropping/tests/test_editor.py
@@ -117,7 +117,7 @@ class EditorTestCase(unittest.TestCase):
         if check_assert:
             self.assertTrue(cropped_scale["can_scale"])
 
-        # set teaser width heigher than image width (776x232):
+        # set teaser width higher than image width (776x232):
         api.portal.set_registry_record(
             "plone.allowed_sizes", ['teaser 800:200'],
         )
@@ -127,7 +127,7 @@ class EditorTestCase(unittest.TestCase):
         if check_assert:
             self.assertFalse(cropped_scale["can_scale"])
 
-        # set teaser height heigher than image height (776x232):
+        # set teaser height higher than image height (776x232):
         api.portal.set_registry_record(
             "plone.allowed_sizes", ['teaser 600:400'],
         )

--- a/src/plone/app/imagecropping/tests/test_editor.py
+++ b/src/plone/app/imagecropping/tests/test_editor.py
@@ -94,12 +94,14 @@ class EditorTestCase(unittest.TestCase):
                 "form.button.Save": "1",
             }
         )
+
         def get_cropped_scale(scales):
             return [s for s in scales if s["id"] == scale_name][0]
 
         # set teaser target width and height lower than image height (776x232):
         api.portal.set_registry_record(
-            "plone.allowed_sizes", ['teaser 600:200'],
+            "plone.allowed_sizes",
+            ["teaser 600:200"],
         )
         cropedit = api.content.get_view("croppingeditor", self.img, request)
         cropedit()
@@ -109,7 +111,8 @@ class EditorTestCase(unittest.TestCase):
 
         # set teaser target width lower than image width (776x232) and height on max ():
         api.portal.set_registry_record(
-            "plone.allowed_sizes", ['teaser 600:65536'],
+            "plone.allowed_sizes",
+            ["teaser 600:65536"],
         )
         cropedit = api.content.get_view("croppingeditor", self.img, request)
         cropedit()
@@ -119,7 +122,8 @@ class EditorTestCase(unittest.TestCase):
 
         # set teaser width higher than image width (776x232):
         api.portal.set_registry_record(
-            "plone.allowed_sizes", ['teaser 800:200'],
+            "plone.allowed_sizes",
+            ["teaser 800:200"],
         )
         cropedit = api.content.get_view("croppingeditor", self.img, request)
         cropedit()
@@ -129,7 +133,8 @@ class EditorTestCase(unittest.TestCase):
 
         # set teaser height higher than image height (776x232):
         api.portal.set_registry_record(
-            "plone.allowed_sizes", ['teaser 600:400'],
+            "plone.allowed_sizes",
+            ["teaser 600:400"],
         )
         cropedit = api.content.get_view("croppingeditor", self.img, request)
         cropedit()


### PR DESCRIPTION
In Plone 6 there are image scales with height `65536` in order to make the height calculated flexible when scaling down to the width. This is a problem in cropping editor, because there the flag `can_scale` checks if width and height of scaled image is larger than the original image.

To make these scales croppable here's my solution proposal:

- `can_scale` only checks that the width of the scaled image is lower equal to the original width.
- if the scaled image height is `65536` we calculate the height for the editor by the ratio of the original width/height.

I'm not really happy with the hard coded pixel value though. I also thought about a checkbox in the settings to discard the maximum check for the editor and leave it up to the integrator to constrain the scales to the valid one.

feedback welcome...

see #130 