### PR TITLE
Register `plone.imagecropping` behavior in profile instead of wiring interface to class in zcml

### DIFF
--- a/news/145.bugfix
+++ b/news/145.bugfix
@@ -1,0 +1,3 @@
+Fix `plone.imagecropping` behavior registration with a GenericSetup profile
+and remove `zcml` Interface/Class registration.
+[petschki]

--- a/src/plone/app/imagecropping/configure.zcml
+++ b/src/plone/app/imagecropping/configure.zcml
@@ -41,10 +41,6 @@
   <subscriber handler=".subscribers.apply_crops_after_copy" />
   <subscriber handler=".subscribers.reindex_after_crop_change" />
 
-  <class class="plone.app.contenttypes.content.Image">
-    <implements interface=".dx.IImageCroppingDX" />
-  </class>
-
   <!-- dexterity cropping adapter -->
   <adapter factory=".dx.CroppingUtilsDexterity" />
 

--- a/src/plone/app/imagecropping/profiles/default/metadata.xml
+++ b/src/plone/app/imagecropping/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>2301</version>
+  <version>2302</version>
 </metadata>

--- a/src/plone/app/imagecropping/profiles/default/types/Image.xml
+++ b/src/plone/app/imagecropping/profiles/default/types/Image.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Image"
+>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.imagecropping" />
+  </property>
+
+</object>

--- a/src/plone/app/imagecropping/profiles/uninstall/types/Image.xml
+++ b/src/plone/app/imagecropping/profiles/uninstall/types/Image.xml
@@ -8,7 +8,9 @@
   <property name="behaviors"
             purge="false"
   >
-    <element value="plone.imagecropping" remove="true" />
+    <element remove="true"
+             value="plone.imagecropping"
+    />
   </property>
 
 </object>

--- a/src/plone/app/imagecropping/profiles/uninstall/types/Image.xml
+++ b/src/plone/app/imagecropping/profiles/uninstall/types/Image.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Image"
+>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.imagecropping" remove="true" />
+  </property>
+
+</object>

--- a/src/plone/app/imagecropping/upgrades/configure.zcml
+++ b/src/plone/app/imagecropping/upgrades/configure.zcml
@@ -82,4 +82,25 @@
         run_deps="True"
         />
   </gs:upgradeSteps>
+
+  <gs:registerProfile
+      name="upgrade_2301_to_2302"
+      title="Upgrade policy GS profile to 2302"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="plone.base.interfaces.IMigratingPloneSiteRoot"
+      directory="profiles/2301_to_2302"
+      />
+
+  <gs:upgradeSteps
+      profile="plone.app.imagecropping:default"
+      source="2301"
+      destination="2302"
+      >
+    <gs:upgradeDepends
+        title="Activate behavior for Image types"
+        import_profile="plone.app.imagecropping.upgrades:upgrade_2301_to_2302"
+        run_deps="True"
+        />
+  </gs:upgradeSteps>
 </configure>

--- a/src/plone/app/imagecropping/upgrades/profiles/2301_to_2302/types/Image.xml
+++ b/src/plone/app/imagecropping/upgrades/profiles/2301_to_2302/types/Image.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Image"
+>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="false"
+  >
+    <element value="plone.imagecropping" />
+  </property>
+
+</object>


### PR DESCRIPTION
If you have `plone.app.imagecropping` in PYTHONPATH but not installed in the addons controlpanel all scales of uploaded images are missing initially. This removes the  zcml registration and adds a `types/Image.xml` configuration with upgrade and uninstall profile.