### PR TITLE
Update catalog metadata when removing cropping info

### DIFF
--- a/news/146.bugfix
+++ b/news/146.bugfix
@@ -1,0 +1,2 @@
+Update catalog metadata when removing cropping info.
+[petschki]

--- a/src/plone/app/imagecropping/dx.py
+++ b/src/plone/app/imagecropping/dx.py
@@ -36,6 +36,12 @@ class CroppingImageScalingFactory(DefaultImageScalingFactory):
         if self.box:
             # do crop stuff first
             data = self._crop(data, self.box)
+            if height >= 65536:
+                # special case for "flexible height" settings:
+                # we calculate the height with the box ratio
+                box_width = self.box[2] - self.box[0]
+                box_height = self.box[3] - self.box[1]
+                height = int(round(width / box_width * box_height))
         return super().create_scale(data, mode, height, width, **parameters)
 
     def __call__(

--- a/src/plone/app/imagecropping/storage.py
+++ b/src/plone/app/imagecropping/storage.py
@@ -23,12 +23,9 @@ class Storage:
         # Call storage with actual time in milliseconds.
         # This always invalidates old scales
         scale_storage = AnnotationStorage(self.context, int(time.time()))
-        # holzhammermethode
-        uids = list(scale_storage.keys())
-        for uid in uids:
-            del scale_storage[uid]
+        scale_storage.clear()
 
-    def remove(self, fieldname, scale, surpress_event=False):
+    def remove(self, fieldname, scale, surpress_event=False, reindex=True):
         # remove info from annotation
         key = self._key(fieldname, scale)
         if key in list(self._storage.keys()):
@@ -37,13 +34,15 @@ class Storage:
         if not surpress_event:
             notify(CroppingInfoRemovedEvent(self.context))
             notify(Purge(self.context))
+        if reindex:
+            self.context.reindexObject()
 
     @property
     def _storage(self):
         return IAnnotations(self.context).setdefault(PAI_STORAGE_KEY, PersistentDict())
 
     def store(self, fieldname, scale, box):
-        self.remove(fieldname, scale)
+        self.remove(fieldname, scale, reindex=False)
         key = self._key(fieldname, scale)
         self._storage[key] = box
 

--- a/src/plone/app/imagecropping/storage.py
+++ b/src/plone/app/imagecropping/storage.py
@@ -25,7 +25,7 @@ class Storage:
         scale_storage = AnnotationStorage(self.context, int(time.time()))
         scale_storage.clear()
 
-    def remove(self, fieldname, scale, surpress_event=False, reindex=True):
+    def remove(self, fieldname, scale, surpress_event=False):
         # remove info from annotation
         key = self._key(fieldname, scale)
         if key in list(self._storage.keys()):
@@ -34,7 +34,6 @@ class Storage:
         if not surpress_event:
             notify(CroppingInfoRemovedEvent(self.context))
             notify(Purge(self.context))
-        if reindex:
             self.context.reindexObject()
 
     @property
@@ -42,7 +41,7 @@ class Storage:
         return IAnnotations(self.context).setdefault(PAI_STORAGE_KEY, PersistentDict())
 
     def store(self, fieldname, scale, box):
-        self.remove(fieldname, scale, reindex=False)
+        self.remove(fieldname, scale, surpress_event=True)
         key = self._key(fieldname, scale)
         self._storage[key] = box
 
@@ -52,6 +51,7 @@ class Storage:
             field._modified = DateTime().millis()  # Force a new hash key
 
         notify(CroppingInfoChangedEvent(self.context))
+        notify(Purge(self.context))
 
     def read(self, fieldname, scale):
         if not scale:

--- a/src/plone/app/imagecropping/tests/test_editor.py
+++ b/src/plone/app/imagecropping/tests/test_editor.py
@@ -157,7 +157,6 @@ class EditorTestCase(unittest.TestCase):
         self.assertCountEqual(
             firedEvents,
             [
-                CroppingInfoRemovedEvent,
                 CroppingInfoChangedEvent,
             ],
         )


### PR DESCRIPTION
Note: Somehow I could not do this via `CroppingInfoRemovedEvent` because this didn't get fired. In addition, the event gets fired when changing the cropping information too, so the object had been reindexed twice... 